### PR TITLE
Remove dead code and fix tests

### DIFF
--- a/augusto/src/ascii_art.rs
+++ b/augusto/src/ascii_art.rs
@@ -149,7 +149,6 @@ pub fn word_art(main_word: &str, filler_word: &str) -> String {
 /// # Returns
 ///
 /// A `String` containing the ASCII art representation
-#[allow(dead_code)]
 pub fn word_art_with_spacing(main_word: &str, filler_word: &str, spacing: usize) -> String {
     if main_word.is_empty() || filler_word.is_empty() {
         return String::new();

--- a/augusto/src/ascii_art.rs
+++ b/augusto/src/ascii_art.rs
@@ -93,47 +93,7 @@ fn get_letter_pattern(letter: char) -> Vec<String> {
 /// - Each letter is displayed using a 5x5 character grid
 /// - Letters are separated by one space
 pub fn word_art(main_word: &str, filler_word: &str) -> String {
-    if main_word.is_empty() || filler_word.is_empty() {
-        return String::new();
-    }
-
-    let main_chars: Vec<char> = main_word.chars().collect();
-    let filler_chars: Vec<char> = filler_word.chars().collect();
-    let mut filler_index = 0;
-
-    // Get patterns for all letters
-    let patterns: Vec<Vec<String>> = main_chars.iter().map(|&c| get_letter_pattern(c)).collect();
-
-    // Build the output line by line
-    let mut output = String::new();
-
-    for line_num in 0..5 {
-        let mut line = String::new();
-
-        for (letter_idx, pattern) in patterns.iter().enumerate() {
-            let pattern_line = &pattern[line_num];
-
-            // Replace each '#' with characters from filler word
-            for ch in pattern_line.chars() {
-                if ch == '#' {
-                    line.push(filler_chars[filler_index % filler_chars.len()]);
-                    filler_index += 1;
-                } else {
-                    line.push(' ');
-                }
-            }
-
-            // Add spacing between letters (except for the last one)
-            if letter_idx < patterns.len() - 1 {
-                line.push(' ');
-            }
-        }
-
-        output.push_str(&line);
-        output.push('\n');
-    }
-
-    output
+    word_art_with_spacing(main_word, filler_word, 1)
 }
 
 /// Creates ASCII art with custom styling options

--- a/augusto/src/ascii_art.rs
+++ b/augusto/src/ascii_art.rs
@@ -244,17 +244,21 @@ mod tests {
         // Tribute to Augusto de Campos' iconic concrete poem LUXO/LIXO
         // "LUXO" (luxury) written with "LIXO" (trash) - a powerful social commentary
         let result = word_art("LUXO", "LIXO");
-        
+
         assert!(!result.is_empty());
-        
+
         // Check that the output contains letters from LIXO
-        assert!(result.contains('L') || result.contains('I') || 
-                result.contains('X') || result.contains('O'));
-        
+        assert!(
+            result.contains('L')
+                || result.contains('I')
+                || result.contains('X')
+                || result.contains('O')
+        );
+
         // Verify the result has 5 lines (one for each row in the 5x5 grid)
         let lines: Vec<&str> = result.lines().collect();
         assert_eq!(lines.len(), 5);
-        
+
         // Each line should have content (not be empty)
         for line in lines {
             assert!(!line.trim().is_empty());

--- a/augusto/src/benchmark.rs
+++ b/augusto/src/benchmark.rs
@@ -202,7 +202,6 @@ fn calculate_iterations(input: &str) -> usize {
 }
 
 /// Benchmark multiple operations and compare them
-#[allow(dead_code)]
 pub struct BenchmarkSuite {
     results: Vec<BenchmarkStats>,
 }
@@ -216,13 +215,11 @@ impl BenchmarkSuite {
     }
 
     /// Add a benchmark result
-    #[allow(dead_code)]
     pub fn add(&mut self, stats: BenchmarkStats) {
         self.results.push(stats);
     }
 
     /// Format comparison results
-    #[allow(dead_code)]
     pub fn format_comparison(&self) -> String {
         if self.results.is_empty() {
             return String::from("No benchmark results to compare.\n");

--- a/augusto/src/benchmark.rs
+++ b/augusto/src/benchmark.rs
@@ -73,33 +73,42 @@ impl BenchmarkStats {
     /// Get a formatted string representation of the stats
     pub fn format(&self) -> String {
         let mut output = String::new();
-        
+
         output.push_str("\n╔════════════════════════════════════════════════════════════╗\n");
         output.push_str("║              PERFORMANCE BENCHMARK RESULTS                 ║\n");
         output.push_str("╚════════════════════════════════════════════════════════════╝\n\n");
-        
+
         output.push_str(&format!("Operation:        {}\n", self.operation));
         output.push_str(&format!("Input:            \"{}\"\n", self.input));
-        output.push_str(&format!("Input length:     {} character(s)\n", self.input.len()));
-        
+        output.push_str(&format!(
+            "Input length:     {} character(s)\n",
+            self.input.len()
+        ));
+
         if let Some(size) = self.output_size {
             output.push_str(&format!("Output size:      {} item(s)\n", size));
         }
-        
+
         output.push('\n');
-        output.push_str(&format!("Total time:       {}\n", Self::format_duration(self.duration)));
+        output.push_str(&format!(
+            "Total time:       {}\n",
+            Self::format_duration(self.duration)
+        ));
         output.push_str(&format!("Iterations:       {}\n", self.iterations));
-        output.push_str(&format!("Avg per run:      {}\n", Self::format_duration(self.avg_duration)));
-        
+        output.push_str(&format!(
+            "Avg per run:      {}\n",
+            Self::format_duration(self.avg_duration)
+        ));
+
         // Calculate throughput
         if self.duration.as_micros() > 0 {
             let ops_per_sec = (self.iterations as f64 / self.duration.as_secs_f64()) as u64;
             output.push_str(&format!("Throughput:       {} ops/sec\n", ops_per_sec));
         }
-        
+
         output.push('\n');
         output.push_str("╚════════════════════════════════════════════════════════════╝\n");
-        
+
         output
     }
 }
@@ -150,11 +159,7 @@ where
 /// Benchmark an operation that returns a result
 ///
 /// Similar to benchmark_operation but captures the output size
-pub fn benchmark_with_result<F, T>(
-    operation: &str,
-    input: &str,
-    mut f: F,
-) -> BenchmarkStats
+pub fn benchmark_with_result<F, T>(operation: &str, input: &str, mut f: F) -> BenchmarkStats
 where
     F: FnMut() -> T,
     T: IntoIterator,
@@ -185,7 +190,7 @@ where
 /// Calculate appropriate number of iterations based on input
 fn calculate_iterations(input: &str) -> usize {
     let len = input.len();
-    
+
     // For very short inputs, do more iterations
     if len <= 3 {
         10000
@@ -226,17 +231,23 @@ impl BenchmarkSuite {
         }
 
         let mut output = String::new();
-        
+
         output.push_str("\n╔════════════════════════════════════════════════════════════╗\n");
         output.push_str("║              BENCHMARK COMPARISON                          ║\n");
         output.push_str("╚════════════════════════════════════════════════════════════╝\n\n");
 
         for (i, stat) in self.results.iter().enumerate() {
-            output.push_str(&format!("{}. {} with input \"{}\"\n", 
-                i + 1, stat.operation, stat.input));
-            output.push_str(&format!("   Time: {} (avg: {})\n", 
+            output.push_str(&format!(
+                "{}. {} with input \"{}\"\n",
+                i + 1,
+                stat.operation,
+                stat.input
+            ));
+            output.push_str(&format!(
+                "   Time: {} (avg: {})\n",
                 BenchmarkStats::format_duration(stat.duration),
-                BenchmarkStats::format_duration(stat.avg_duration)));
+                BenchmarkStats::format_duration(stat.avg_duration)
+            ));
             if let Some(size) = stat.output_size {
                 output.push_str(&format!("   Output: {} items\n", size));
             }
@@ -325,16 +336,16 @@ mod tests {
     #[test]
     fn test_benchmark_suite() {
         let mut suite = BenchmarkSuite::new();
-        
+
         let stats1 = BenchmarkStats::new(
             "op1".to_string(),
             "test".to_string(),
             Duration::from_millis(10),
             100,
         );
-        
+
         suite.add(stats1);
-        
+
         let comparison = suite.format_comparison();
         assert!(comparison.contains("op1"));
         assert!(comparison.contains("test"));

--- a/augusto/src/main.rs
+++ b/augusto/src/main.rs
@@ -65,7 +65,20 @@ fn main() {
                 eprintln!("         augusto art \"RUST\" \"code\" 2");
                 std::process::exit(1);
             }
-            let spacing = args.get(4).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
+            let spacing = if let Some(s) = args.get(4) {
+                match s.parse::<usize>() {
+                    Ok(val) => val,
+                    Err(_) => {
+                        eprintln!("Error: Invalid spacing value '{}'. Spacing must be a non-negative integer.", s);
+                        eprintln!("\nUsage: augusto art <main_word> <filler_word> [spacing]");
+                        eprintln!("Example: augusto art \"RUST\" \"code\"");
+                        eprintln!("         augusto art \"RUST\" \"code\" 2");
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                0
+            };
             run_ascii_art(&args[2], &args[3], spacing);
         }
         "bench" | "benchmark" | "perf" => {

--- a/augusto/src/main.rs
+++ b/augusto/src/main.rs
@@ -171,7 +171,7 @@ fn run_ascii_art(main_word: &str, filler_word: &str, spacing: usize) {
         std::process::exit(1);
     }
 
-    // Generate ASCII art, always using word_art_with_spacing and defaulting spacing to 1 if 0
+    // Generate ASCII art; if spacing is 0, default to 1
     let effective_spacing = if spacing == 0 { 1 } else { spacing };
     let art = ascii_art::word_art_with_spacing(main_word, filler_word, effective_spacing);
     println!("{}", art);

--- a/augusto/src/main.rs
+++ b/augusto/src/main.rs
@@ -193,14 +193,14 @@ fn run_benchmark(args: &[String]) {
                 eprintln!("\nUsage: augusto bench anagram <word>");
                 std::process::exit(1);
             }
-            
+
             let input = &args[1];
-            
+
             // Benchmark anagram generation
             let stats = benchmark::benchmark_with_result("Anagram Generation", input, || {
                 anagram::letter_combinations(input)
             });
-            
+
             println!("{}", stats);
         }
         "art" | "ascii" => {
@@ -209,19 +209,17 @@ fn run_benchmark(args: &[String]) {
                 eprintln!("\nUsage: augusto bench art <main_word> <filler_word>");
                 std::process::exit(1);
             }
-            
+
             let main_word = &args[1];
             let filler_word = &args[2];
-            
+
             // Benchmark ASCII art generation
             let stats = benchmark::benchmark_operation(
                 "ASCII Art Generation",
                 &format!("{}+{}", main_word, filler_word),
-                || {
-                    ascii_art::word_art(main_word, filler_word)
-                },
+                || ascii_art::word_art(main_word, filler_word),
             );
-            
+
             println!("{}", stats);
         }
         _ => {

--- a/augusto/src/main.rs
+++ b/augusto/src/main.rs
@@ -171,12 +171,9 @@ fn run_ascii_art(main_word: &str, filler_word: &str, spacing: usize) {
         std::process::exit(1);
     }
 
-    // Generate ASCII art with spacing if specified
-    let art = if spacing > 0 {
-        ascii_art::word_art_with_spacing(main_word, filler_word, spacing)
-    } else {
-        ascii_art::word_art(main_word, filler_word)
-    };
+    // Generate ASCII art, always using word_art_with_spacing and defaulting spacing to 1 if 0
+    let effective_spacing = if spacing == 0 { 1 } else { spacing };
+    let art = ascii_art::word_art_with_spacing(main_word, filler_word, effective_spacing);
     println!("{}", art);
 }
 

--- a/augusto/src/main.rs
+++ b/augusto/src/main.rs
@@ -171,9 +171,12 @@ fn run_ascii_art(main_word: &str, filler_word: &str, spacing: usize) {
         std::process::exit(1);
     }
 
-    // Generate ASCII art; if spacing is 0, default to 1
-    let effective_spacing = if spacing == 0 { 1 } else { spacing };
-    let art = ascii_art::word_art_with_spacing(main_word, filler_word, effective_spacing);
+    // Generate ASCII art; use word_art for default spacing (0 or 1)
+    let art = if spacing == 0 || spacing == 1 {
+        ascii_art::word_art(main_word, filler_word)
+    } else {
+        ascii_art::word_art_with_spacing(main_word, filler_word, spacing)
+    };
     println!("{}", art);
 }
 


### PR DESCRIPTION
This pull request adds a new command for comparing anagram performance, improves the flexibility of the ASCII art feature, and cleans up the codebase by removing unnecessary `#[allow(dead_code)]` attributes. The most significant changes are grouped below.

### New Features

* Added a `compare` command to the CLI (`augusto/src/main.rs`), allowing users to benchmark and compare the performance of anagram generation for multiple words. The implementation includes a new `run_comparison` function and updates to the help/usage output. [[1]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4R81-R89) [[2]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4L104-R126) [[3]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4R227-R245)

### ASCII Art Improvements

* Updated the `art` command to accept an optional `spacing` argument, which is passed to the ASCII art generator. The usage message and example output have been updated accordingly. The `run_ascii_art` function now supports spacing, and the CLI parses this argument. [[1]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4L63-R69) [[2]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4L136-R150) [[3]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4L147-R166) [[4]](diffhunk://#diff-3bc085e8b41b44615f5ac3e1f937d33bc25e555819e624693b9539553665cbc4L104-R126)

### Codebase Cleanup

* Removed unnecessary `#[allow(dead_code)]` attributes from the ASCII art and benchmarking modules, reducing clutter and improving code clarity. [[1]](diffhunk://#diff-e0e62023122d488335898a8a5492827addd9b1bd04539a9b97a8d673d47bcd29L152) [[2]](diffhunk://#diff-a593778fcc43492816662f14d625354105ba1941ef75d08002fe449a21ede6b9L205) [[3]](diffhunk://#diff-a593778fcc43492816662f14d625354105ba1941ef75d08002fe449a21ede6b9L219-L225)